### PR TITLE
Limit backup accumulation

### DIFF
--- a/handling/user_coins.py
+++ b/handling/user_coins.py
@@ -1,6 +1,7 @@
 import os
 import json
 import shutil
+from utils.backup_rotation import rotate_backups
 from datetime import datetime
 
 # ─── Mounted volume base path ───────────────────────────
@@ -8,6 +9,7 @@ BASE_DIR = "/mnt/data"
 USER_DATA_PATH = os.path.join(BASE_DIR, "data/user_coins.json")
 BACKUP_DIR = os.path.join(BASE_DIR, "backups")
 USER_LOG_PATH = os.path.join(BASE_DIR, "logs/user_info.json")
+MAX_BACKUPS = 5
 
 # ─── Ensure coin file exists ────────────────────────────
 def ensure_user_file():
@@ -23,6 +25,7 @@ def backup_user_coins():
     backup_path = os.path.join(BACKUP_DIR, f"coins_backup_{timestamp}.json")
     shutil.copy(USER_DATA_PATH, backup_path)
     print(f"[INFO] ✅ Coin backup saved: {backup_path}")
+    rotate_backups(BACKUP_DIR, "coins_backup_*.json", MAX_BACKUPS)
 
 # ─── User metadata logging ──────────────────────────────
 def log_user_info(user_id, first_name=None, username=None):

--- a/routes/tasks.py
+++ b/routes/tasks.py
@@ -1,6 +1,7 @@
 import os
 import json
 import shutil
+from utils.backup_rotation import rotate_backups
 from datetime import datetime
 from flask import Blueprint, request, jsonify
 
@@ -11,6 +12,7 @@ BASE_DIR = "/mnt/data"
 TASKS_PATH = os.path.join(BASE_DIR, "data/user_tasks.json")
 BACKUP_DIR = os.path.join(BASE_DIR, "backups")
 USER_LOG_PATH = os.path.join(BASE_DIR, "logs/user_info.json")
+MAX_BACKUPS = 5
 
 # ─── Internal utilities ─────────────────────────────────
 def ensure_file():
@@ -34,6 +36,7 @@ def backup_tasks():
     backup_path = os.path.join(BACKUP_DIR, f"tasks_backup_{timestamp}.json")
     shutil.copy(TASKS_PATH, backup_path)
     print(f"[INFO] ✅ Task backup saved: {backup_path}")
+    rotate_backups(BACKUP_DIR, "tasks_backup_*.json", MAX_BACKUPS)
 
 def log_user_info(user_id, first_name=None, username=None):
     os.makedirs(os.path.dirname(USER_LOG_PATH), exist_ok=True)

--- a/utils/backup_rotation.py
+++ b/utils/backup_rotation.py
@@ -1,0 +1,18 @@
+import os
+import glob
+
+
+def rotate_backups(directory: str, pattern: str, max_files: int = 5) -> None:
+    """Keep only the newest backup files matching the pattern."""
+    files = sorted(
+        glob.glob(os.path.join(directory, pattern))
+    )
+    if len(files) <= max_files:
+        return
+    old_files = files[:-max_files]
+    for path in old_files:
+        try:
+            os.remove(path)
+            print(f"[INFO] Deleted old backup: {path}")
+        except OSError as e:
+            print(f"[ERROR] Failed to delete {path}: {e}")


### PR DESCRIPTION
## Summary
- add a simple backup rotation utility
- keep only 5 coin and task backups

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421b48b6008324b91abbfd28204d16